### PR TITLE
Make PyYeti compatible with strict PEP-517 package managers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "distutils", "numpy"]
+requires = ["setuptools","numpy"]
 build-backend = "setuptools.build_meta"

--- a/pyyeti/__init__.py
+++ b/pyyeti/__init__.py
@@ -26,5 +26,6 @@ pyYeti has tools mostly related to structural dynamics:
     * Other miscellaneous tools
 
 """
+from importlib.metadata import version
 
-__version__ = "1.1.8"
+__version__ = version()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup, find_packages, Extension
 from distutils.command.build_ext import build_ext
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 import numpy
-import pyyeti
 import os
 
 
@@ -97,7 +96,7 @@ def run_setup(with_binary):
     install_requires = check_dependencies()
     setup(
         name="pyyeti",
-        version=pyyeti.__version__,
+        version="1.1.18",
         url="http://github.com/twmacro/pyyeti/",
         license="BSD",
         author="Tim Widrick",


### PR DESCRIPTION
Culmination of multiple debugging commits resulting in a state that can be used in the latest version of poetry, which uses strict PEP-517 compliance. 