### PR TITLE
Correct version number typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ def run_setup(with_binary):
     install_requires = check_dependencies()
     setup(
         name="pyyeti",
-        version="1.1.18",
+        version="1.1.8",
         url="http://github.com/twmacro/pyyeti/",
         license="BSD",
         author="Tim Widrick",


### PR DESCRIPTION
Change version number to properly match the existing pyyeti version. 