### PR TITLE
Swapped signs for shifting geometry based on the new CS origin

### DIFF
--- a/pyyeti/nastran/n2p.py
+++ b/pyyeti/nastran/n2p.py
@@ -474,10 +474,10 @@ def replace_basic_cs(uset, new_cs_id, new_cs_in_basic=None):
     # 1. adjust all node locations:
     #           new_location_in_basic = T @ old_location + A
     A = new_cs_in_basic[0].reshape(3, 1)
-    xyz[::6] = (T @ xyz[::6].T + A).T
+    xyz[::6] = (T @ xyz[::6].T - A).T
 
     # 2. adjust all coord-system origins similarly:
-    xyz[2::6] = (T @ xyz[2::6].T + A).T
+    xyz[2::6] = (T @ xyz[2::6].T - A).T
 
     # 3. fix up all the ids ... 0 --> new_cs_id
     pv = current_cs_ids == 0


### PR DESCRIPTION
I believe these signs have the opposite the intended effect. If I define a new rectangular coordinate system, shifted 10 inches up in CORD2R format as
```
[10, 0, 0]
[10, 0, 1]
[11, 0, 0]
```
shouldn't all the x values be reduced by that amount? That would make the new uset values match the locations of those nodes in the new CS. 

Perhaps I am misunderstanding how this function is intended to be used. My goal was to get a uset in a new coordinate system, and the current implementation seems more like "replace definition cs," where `new_cs_in_basic=` is treated as the CS of the passed in uset, and the output uset is in basic.